### PR TITLE
Security update

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.16
       - name: Launch Cluster
         uses: helm/kind-action@v1.0.0
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alcideio/iskan
 
-go 1.13
+go 1.16
 
 require (
 	cloud.google.com/go v0.65.0

--- a/htmlviewer/package.json
+++ b/htmlviewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alcideio/iskan-viewer",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": false,
   "keywords": [
     "kubernetes",


### PR DESCRIPTION
- update go 1.16
- update node deps
- switch github actions workflow to use checkout v2 (#16)